### PR TITLE
Skip zero-sized ranges

### DIFF
--- a/src/format_meta.rs
+++ b/src/format_meta.rs
@@ -1,7 +1,7 @@
 use failure::Error;
 use hexplay::{self, HexViewBuilder, CODEPAGE_ASCII};
 use metagoblin;
-use metagoblin::Object;
+use metagoblin::{Object, Tag};
 use prettytable::Cell;
 use prettytable::Row;
 
@@ -40,6 +40,9 @@ impl<'a> Meta<'a> {
             new_table(row![b->"Name", b->"Tag", b->"Range", b->"Percent", b->"Size", b->spaces]);
 
         for &(ref range, ref data) in &franges {
+            if let Tag::Zero = data.tag {
+                continue;
+            }
             let size = range.len() - 1;
             if size == 0 {
                 continue;


### PR DESCRIPTION
Thanks for this awesome tool!

I ran into a panic when trying bingrep against `/bin/ls` and the problem was that it was trying to represent the `.bss` section as a range in the binary, but as you know that section takes no space in the binary.
