### PR TITLE
Replace structopt with clap 3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +41,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +58,7 @@ version = "0.9.1"
 dependencies = [
  "anyhow",
  "atty",
+ "clap",
  "cpp_demangle",
  "env_logger",
  "hexplay",
@@ -68,8 +66,6 @@ dependencies = [
  "prettytable-rs",
  "rustc-demangle",
  "scroll 0.11.0",
- "structopt",
- "structopt-derive",
  "termcolor 1.1.2",
 ]
 
@@ -116,17 +112,33 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor 1.1.2",
+ "terminal_size",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -235,13 +247,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.3.3"
+name = "hashbrown"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -267,6 +282,16 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "indexmap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
 
 [[package]]
 name = "itoa"
@@ -320,6 +345,15 @@ dependencies = [
  "log",
  "memrange",
  "theban_interval_tree",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -535,33 +569,9 @@ checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -604,12 +614,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "terminal_size"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
- "unicode-width",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+dependencies = [
+ "terminal_size",
 ]
 
 [[package]]
@@ -635,12 +655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,12 +665,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,13 @@ include = ["src/**/*", "Cargo.toml", "Cargo.lock", "LICENSE", "README.md", "etc/
 atty = "0.2"
 hexplay = "0.2"
 termcolor = "1"
-structopt = "0.3"
-structopt-derive = "0.4"
 rustc-demangle = "0.1"
 cpp_demangle = "0.3"
 scroll = "0.11"
 prettytable-rs = "0.8"
 env_logger = "0.9"
 anyhow = "1"
+clap = { version = "3", features = ["derive", "wrap_help"] }
 
 [dependencies.metagoblin]
 version = "0.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,8 @@ use std::io::{Read, Write};
 use std::path::Path;
 
 use anyhow::Error;
+use clap::Parser;
 use metagoblin::{elf, mach, Hint, Object};
-use structopt::StructOpt;
 
 mod format;
 mod format_elf;
@@ -21,55 +21,55 @@ use crate::format_meta::Meta;
 mod format_pe;
 use crate::format_pe::PortableExecutable;
 
-#[derive(StructOpt, Debug, Clone)]
-#[structopt(
+#[derive(Parser, Debug, Clone)]
+#[clap(
     name = "bingrep",
     about = "bingrep - grepping through binaries since 2017"
 )]
 pub struct Opt {
-    #[structopt(
+    #[clap(
         long = "extract",
         help = "Extract from an archive the object file which contains the given symbol"
     )]
     extract: Option<String>,
 
-    #[structopt(
+    #[clap(
         long = "ranges",
         help = "Print a high level overview of the file offset ranges in this binary"
     )]
     ranges: bool,
 
-    #[structopt(
+    #[clap(
         long = "hex",
         help = "Print a colored and semantically tagged hex table"
     )]
     hex: bool,
 
-    #[structopt(
-        short = "d",
+    #[clap(
+        short = 'd',
         long = "debug",
         help = "Print debug version of parse results"
     )]
     debug: bool,
 
-    #[structopt(
-        short = "t",
+    #[clap(
+        short = 't',
         long = "truncate",
         help = "Truncate string results to X characters",
         default_value = "2048"
     )]
     truncate: usize,
 
-    #[structopt(long = "color", help = "Forces coloring, even in files and pipes")]
+    #[clap(long = "color", help = "Forces coloring, even in files and pipes")]
     color: bool,
 
-    #[structopt(short = "s", long = "search", help = "Search for string")]
+    #[clap(short = 's', long = "search", help = "Search for string")]
     search: Option<String>,
 
-    #[structopt(short = "D", long = "demangle", help = "Apply Rust/C++ demangling")]
+    #[clap(short = 'D', long = "demangle", help = "Apply Rust/C++ demangling")]
     demangle: bool,
 
-    #[structopt(help = "Binary file")]
+    #[clap(help = "Binary file")]
     input: String,
 }
 
@@ -173,7 +173,7 @@ fn run(opt: Opt) -> Result<(), Error> {
 }
 
 pub fn main() {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
     env_logger::init();
     match run(opt) {
         Ok(()) => (),


### PR DESCRIPTION
No need to use structopt now that clap 3.0 supports the same derive feature.