### PR TITLE
feat(args): add `--version` flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,8 @@ use crate::format_pe::{is_pe_object_file_header, PEObjectFile, PortableExecutabl
 #[derive(Parser, Debug, Clone)]
 #[clap(
     name = "bingrep",
-    about = "bingrep - grepping through binaries since 2017"
+    about = "bingrep - grepping through binaries since 2017",
+    version
 )]
 pub struct Opt {
     #[clap(


### PR DESCRIPTION
This PR updates the `Opt` struct for enabling the `-V` and `--version` flags thus makes it possible to print the projects version.

Signed-off-by: Orhun Parmaksız <orhunparmaksiz@gmail.com>
