### PR TITLE
elf: Print DT_RUNPATH as text

### DIFF
--- a/src/format_elf.rs
+++ b/src/format_elf.rs
@@ -432,12 +432,12 @@ impl<'bytes> Elf<'bytes> {
         use dynamic::{
             tag_to_str, DT_FINI, DT_FINI_ARRAY, DT_FINI_ARRAYSZ, DT_GNU_HASH, DT_INIT,
             DT_INIT_ARRAY, DT_INIT_ARRAYSZ, DT_JMPREL, DT_NEEDED, DT_PLTGOT, DT_PLTRELSZ, DT_RELA,
-            DT_RELASZ, DT_RPATH, DT_STRSZ, DT_STRTAB, DT_SYMTAB, DT_VERNEED, DT_VERSYM,
+            DT_RELASZ, DT_RPATH, DT_RUNPATH, DT_STRSZ, DT_STRTAB, DT_SYMTAB, DT_VERNEED, DT_VERSYM,
         };
 
         fmt_cyan(fmt, &format!("{:>16} ", tag_to_str(dyn_sym.d_tag)))?;
         match dyn_sym.d_tag {
-            DT_RPATH => {
+            DT_RPATH | DT_RUNPATH => {
                 let val = usize::try_from(dyn_sym.d_val)?;
                 let name = self.elf.dynstrtab.get_at(val).unwrap_or("<error>");
                 fmt_string(fmt, &self.args, name)?;


### PR DESCRIPTION
Closes: #43

# Before

```console
$ bingrep ~/CLionProjects/whisper.cpp/build/bin/whisper-cli 
[...]
Dynamic(33):
       DT_NEEDED libwhisper.so.1
       DT_NEEDED libggml.so.0
       DT_NEEDED libstdc++.so.6
       DT_NEEDED libm.so.6
       DT_NEEDED libgcc_s.so.1
       DT_NEEDED libc.so.6
      DT_RUNPATH 0x6995
         DT_INIT 0xe000
         DT_FINI 0xb4c04
[...]
```

# After

```console
$ cargo run -- ~/CLionProjects/whisper.cpp/build/bin/whisper-cli
[...]
Dynamic(33):
       DT_NEEDED libwhisper.so.1
       DT_NEEDED libggml.so.0
       DT_NEEDED libstdc++.so.6
       DT_NEEDED libm.so.6
       DT_NEEDED libgcc_s.so.1
       DT_NEEDED libc.so.6
      DT_RUNPATH /home/home/CLionProjects/whisper.cpp/build/src:/home/home/CLionProjects/whisper.cpp/build/ggml/src:/home/home/CLionProjects/whisper.cpp/build/ggml/src/ggml-hip:/opt/rocm-7.0.1/lib:/opt/rocm/lib:
         DT_INIT 0xe000
         DT_FINI 0xb4c04
[...]
```